### PR TITLE
fix: Resolve build errors

### DIFF
--- a/Feather/Views/Library/Install/InstallProgressView.swift
+++ b/Feather/Views/Library/Install/InstallProgressView.swift
@@ -293,7 +293,7 @@ struct InstallProgressView: View {
 						)
 				)
 			} else {
-				Text(viewModel.currentStep)
+				Text("\(viewModel.currentStep)")
 					.font(.system(size: 13, weight: .medium))
 					.foregroundStyle(.secondary)
 					.multilineTextAlignment(.center)

--- a/Feather/Views/Settings/Certificates/CertificatesView.swift
+++ b/Feather/Views/Settings/Certificates/CertificatesView.swift
@@ -57,7 +57,7 @@ struct CertificatesView: View {
 					} label: {
 						Image(systemName: "plus.circle.fill")
 							.font(.system(size: 22, weight: .medium))
-							.foregroundStyle(.accentColor)
+							.foregroundStyle(Color.accentColor)
 					}
 				}
 			}

--- a/Feather/Views/Settings/SettingsView.swift
+++ b/Feather/Views/Settings/SettingsView.swift
@@ -107,9 +107,13 @@ struct SettingsView: View {
                         NavigationLink(destination: AppIconView()) {
                             modernSettingsRow(icon: "app.badge.fill", title: "App Icons", color: .pink)
                         }
-                        NavigationLink(destination: CheckForUpdatesView(), isActive: $navigateToCheckForUpdates) {
+                        NavigationLink(destination: CheckForUpdatesView()) {
                             modernSettingsRow(icon: "arrow.triangle.2.circlepath", title: "Updates", color: .green)
                         }
+                        .background(
+                            NavigationLink(destination: CheckForUpdatesView(), isActive: $navigateToCheckForUpdates) { EmptyView() }
+                                .opacity(0)
+                        )
                     } header: {
                         sectionHeader("App", icon: "app.fill")
                     }

--- a/Feather/Views/TabView/Bars/CustomTabBarUI.swift
+++ b/Feather/Views/TabView/Bars/CustomTabBarUI.swift
@@ -210,7 +210,6 @@ struct CustomTabBarUI: View {
                                 : AnyShapeStyle(Color.secondary)
                         )
                         .scaleEffect(isSelected ? 1.0 : 0.9)
-                        .symbolEffect(.bounce, value: isSelected)
                 }
                 .frame(height: 36)
                 


### PR DESCRIPTION
- InstallProgressView: Convert viewModel.currentStep to String for Text initializer
- CertificatesView: Use Color.accentColor instead of .accentColor for foregroundStyle
- CustomTabBarUI: Remove .symbolEffect modifier (iOS 17+ only)
- SettingsView: Keep deprecated NavigationLink for programmatic navigation compatibility