### PR TITLE
fix: Resolve SwiftUI build errors

### DIFF
--- a/Feather/Views/Files/FileToolsViews.swift
+++ b/Feather/Views/Files/FileToolsViews.swift
@@ -1529,7 +1529,7 @@ struct Base64ToolView: View {
                         Text(inputText.isEmpty ? "Enter Base64" : (isValid ? "Valid Base64" : "Invalid Base64"))
                     }
                     .font(.caption)
-                    .foregroundStyle(inputText.isEmpty ? .secondary : (isValid ? .green : .red))
+                    .foregroundColor(inputText.isEmpty ? .secondary : (isValid ? .green : .red))
                 }
             }
         }

--- a/Feather/Views/Settings/Certificates/Info/CertificatesInfoView.swift
+++ b/Feather/Views/Settings/Certificates/Info/CertificatesInfoView.swift
@@ -506,7 +506,7 @@ struct CertificatesInfoView: View {
         }
         .sheet(isPresented: $showExportSheet) {
             if let url = exportedFileURL {
-                ShareSheet(activityItems: [url])
+                ShareSheet(urls: [url])
             }
         }
     }


### PR DESCRIPTION
- Fix foregroundStyle type mismatch in Base64ToolView by using foregroundColor
- Fix ShareSheet argument label from 'activityItems:' to 'urls:'