### PR TITLE
Fix additional Swift compilation errors

### DIFF
--- a/Feather/Views/Developer/DeveloperView.swift
+++ b/Feather/Views/Developer/DeveloperView.swift
@@ -2488,7 +2488,7 @@ struct IPAInspectorView: View {
         
         // Analyze main executable binary
         var binaryInfo: MachOAnalyzer.BinaryInfo? = nil
-        var signatureInfo: CodeSignatureAnalyzer.SignatureInfo? = nil
+        let signatureInfo: CodeSignatureAnalyzer.SignatureInfo? = nil
         var executableName: String? = nil
         var supportedArchitectures: [String] = []
         var isEncrypted = false

--- a/Feather/Views/Settings/Feedback/FeedbackView.swift
+++ b/Feather/Views/Settings/Feedback/FeedbackView.swift
@@ -106,7 +106,7 @@ struct FeedbackView: View {
                     } label: {
                         Image(systemName: showMarkdownPreview ? "eye.fill" : "eye")
                             .font(.system(size: 16))
-                            .foregroundStyle(.accentColor)
+                            .foregroundStyle(Color.accentColor)
                     }
                 }
             }
@@ -395,7 +395,7 @@ struct FeedbackView: View {
             Spacer()
             Image(systemName: "plus.circle.fill")
                 .font(.system(size: 22))
-                .foregroundStyle(.accentColor)
+                .foregroundStyle(Color.accentColor)
         }
         .padding(14)
         .background(
@@ -450,7 +450,7 @@ struct FeedbackView: View {
             Text("Add")
                 .font(.system(size: 11, weight: .medium))
         }
-        .foregroundStyle(.accentColor)
+        .foregroundStyle(Color.accentColor)
         .frame(width: 80, height: 80)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)


### PR DESCRIPTION
- Replace .foregroundStyle(.accentColor) with .foregroundStyle(Color.accentColor) to fix 'Type ShapeStyle has no member accentColor' errors in FeedbackView.swift
- Change signatureInfo from var to let in DeveloperView.swift (was never mutated)