### PR TITLE
Fix remaining Swift compilation errors

### DIFF
--- a/Feather/Views/Developer/DeveloperView.swift
+++ b/Feather/Views/Developer/DeveloperView.swift
@@ -1608,7 +1608,7 @@ struct MachOAnalyzer {
         var segments: [SegmentInfo] = []
         var minOSVersion: String? = nil
         var sdkVersion: String? = nil
-        var buildVersion: String? = nil
+        let buildVersion: String? = nil
         
         guard data.count >= 32 else {
             return BinaryInfo(architectures: [], isUniversal: false, is64Bit: true, linkedLibraries: [], rpaths: [], hasCodeSignature: false, isEncrypted: false, encryptionInfo: nil, segments: [], minOSVersion: nil, sdkVersion: nil, buildVersion: nil)

--- a/Feather/Views/Settings/Feedback/FeedbackView.swift
+++ b/Feather/Views/Settings/Feedback/FeedbackView.swift
@@ -243,7 +243,7 @@ struct FeedbackView: View {
         HStack(spacing: 12) {
             Image(systemName: "pencil.line")
                 .font(.system(size: 16))
-                .foregroundStyle(focusedField == .title ? .accentColor : .secondary)
+                .foregroundStyle(focusedField == .title ? Color.accentColor : Color.secondary)
             
             TextField("Brief summary of your feedback", text: $feedbackTitle)
                 .font(.system(size: 15))


### PR DESCRIPTION
- Fix ternary expression in FeedbackView.swift line 246: use Color.accentColor and Color.secondary explicitly for ShapeStyle compatibility
- Change buildVersion from var to let in DeveloperView.swift parseMachO64 function (was never mutated)