### PR TITLE
Fix foregroundStyle type error in FeedbackView

### DIFF
--- a/Feather/Views/Settings/Feedback/FeedbackView.swift
+++ b/Feather/Views/Settings/Feedback/FeedbackView.swift
@@ -528,7 +528,7 @@ struct FeedbackView: View {
                     
                     Image(systemName: isOn.wrappedValue ? "checkmark.circle.fill" : "circle")
                         .font(.system(size: 18))
-                        .foregroundStyle(isOn.wrappedValue ? color : .tertiary)
+                        .foregroundStyle(isOn.wrappedValue ? color : Color.gray.opacity(0.4))
                 }
                 
                 VStack(alignment: .leading, spacing: 2) {


### PR DESCRIPTION
Replace .tertiary with Color.gray.opacity(0.4) to fix type mismatch in ternary expression for ShapeStyle.