### PR TITLE
feat: Add new HomeView dashboard with quick actions, status, and At A…

### DIFF
--- a/Feather/Views/ExperimentalUI/ExperimentalTabbarView.swift
+++ b/Feather/Views/ExperimentalUI/ExperimentalTabbarView.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct ExperimentalTabbarView: View {
-    @State private var selectedTab: TabEnum = .home
-    @AppStorage("Feather.tabBar.home") private var showHome = true
+    @State private var selectedTab: TabEnum = .dashboard
+    @AppStorage("Feather.tabBar.dashboard") private var showDashboard = true
+    @AppStorage("Feather.tabBar.sources") private var showSources = true
     @AppStorage("Feather.tabBar.library") private var showLibrary = true
     @AppStorage("Feather.tabBar.files") private var showFiles = true
     @AppStorage("Feather.tabBar.guides") private var showGuides = true
@@ -22,7 +23,8 @@ struct ExperimentalTabbarView: View {
     
     var visibleTabs: [TabEnum] {
         var tabs: [TabEnum] = []
-        if showHome { tabs.append(.home) }
+        if showDashboard { tabs.append(.dashboard) }
+        if showSources { tabs.append(.sources) }
         if showLibrary { tabs.append(.library) }
         if showFiles { tabs.append(.files) }
         
@@ -100,7 +102,9 @@ struct ExperimentalTabContent: View {
     var body: some View {
         Group {
             switch tab {
-            case .home:
+            case .dashboard:
+                HomeView()
+            case .sources:
                 ExperimentalSourcesView()
             case .library:
                 ExperimentalLibraryView()

--- a/Feather/Views/Home/HomeView.swift
+++ b/Feather/Views/Home/HomeView.swift
@@ -1,0 +1,542 @@
+import SwiftUI
+import CoreData
+import NimbleViews
+
+// MARK: - HomeView - Dashboard with Quick Actions, Status, and At A Glance
+struct HomeView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @AppStorage("Feather.greetingsName") private var _greetingsName: String = ""
+    
+    // Fetch requests for data
+    @FetchRequest(
+        entity: CertificatePair.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \CertificatePair.date, ascending: false)]
+    ) private var _certificates: FetchedResults<CertificatePair>
+    
+    @FetchRequest(
+        entity: AltSource.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \AltSource.order, ascending: true)]
+    ) private var _sources: FetchedResults<AltSource>
+    
+    @FetchRequest(
+        entity: Signed.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \Signed.date, ascending: false)]
+    ) private var _signedApps: FetchedResults<Signed>
+    
+    @FetchRequest(
+        entity: Imported.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \Imported.date, ascending: false)]
+    ) private var _importedApps: FetchedResults<Imported>
+    
+    @StateObject var viewModel = SourcesViewModel.shared
+    
+    // Sheet states
+    @State private var _showAddCertificate = false
+    @State private var _showAddSource = false
+    @State private var _showSignApp = false
+    @State private var _showImportApp = false
+    @State private var _appearAnimation = false
+    
+    private var greetingText: String {
+        let hour = Calendar.current.component(.hour, from: Date())
+        let greeting: String
+        
+        if hour >= 5 && hour < 12 {
+            greeting = String.localized("Good Morning")
+        } else if hour >= 12 && hour < 17 {
+            greeting = String.localized("Good Afternoon")
+        } else {
+            greeting = String.localized("Good Night")
+        }
+        
+        if _greetingsName.isEmpty {
+            return greeting
+        } else {
+            return "\(greeting), \(_greetingsName)!"
+        }
+    }
+    
+    private var portalVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+    }
+    
+    private var buildNumber: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
+    }
+    
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 0) {
+                    // Header
+                    headerSection
+                    
+                    VStack(spacing: 24) {
+                        // Quick Actions
+                        quickActionsSection
+                        
+                        // Status Section
+                        statusSection
+                        
+                        // At A Glance Section
+                        atAGlanceSection
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 100)
+                }
+            }
+            .background(Color(.systemBackground))
+            .navigationBarHidden(true)
+            .sheet(isPresented: $_showAddCertificate) {
+                CertificatesAddView()
+                    .presentationDetents([.medium])
+            }
+            .sheet(isPresented: $_showAddSource) {
+                SourcesAddView()
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.visible)
+            }
+            .sheet(isPresented: $_showImportApp) {
+                FileImporterRepresentableView(
+                    allowedContentTypes: [.ipa, .tipa],
+                    allowsMultipleSelection: true,
+                    onDocumentsPicked: { urls in
+                        for url in urls {
+                            let id = "FeatherManualDownload_\(UUID().uuidString)"
+                            let dl = DownloadManager.shared.startArchive(from: url, id: id)
+                            try? DownloadManager.shared.handlePachageFile(url: url, dl: dl)
+                        }
+                    }
+                )
+                .ignoresSafeArea()
+            }
+        }
+        .onAppear {
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
+                _appearAnimation = true
+            }
+        }
+        .task(id: Array(_sources)) {
+            await viewModel.fetchSources(_sources)
+        }
+    }
+    
+    // MARK: - Header Section
+    private var headerSection: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(greetingText)
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+                
+                Text("Portal Dashboard")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.secondary)
+            }
+            
+            Spacer()
+            
+            // App Icon
+            if let iconName = Bundle.main.iconFileName,
+               let icon = UIImage(named: iconName) {
+                Image(uiImage: icon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 44, height: 44)
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    .shadow(color: .accentColor.opacity(0.3), radius: 6, x: 0, y: 3)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 16)
+        .padding(.bottom, 24)
+        .opacity(_appearAnimation ? 1 : 0)
+        .offset(y: _appearAnimation ? 0 : -20)
+        .animation(.spring(response: 0.5, dampingFraction: 0.8), value: _appearAnimation)
+    }
+    
+    // MARK: - Quick Actions Section
+    private var quickActionsSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            sectionHeader("Quick Actions", icon: "bolt.fill")
+            
+            LazyVGrid(columns: [
+                GridItem(.flexible(), spacing: 12),
+                GridItem(.flexible(), spacing: 12)
+            ], spacing: 12) {
+                QuickActionCard(
+                    title: "Add Certificate",
+                    icon: "checkmark.seal.fill",
+                    color: .green
+                ) {
+                    _showAddCertificate = true
+                    HapticsManager.shared.softImpact()
+                }
+                
+                QuickActionCard(
+                    title: "Add Source",
+                    icon: "globe.desk.fill",
+                    color: .cyan
+                ) {
+                    _showAddSource = true
+                    HapticsManager.shared.softImpact()
+                }
+                
+                QuickActionCard(
+                    title: "Import App",
+                    icon: "square.and.arrow.down.fill",
+                    color: .orange
+                ) {
+                    _showImportApp = true
+                    HapticsManager.shared.softImpact()
+                }
+                
+                NavigationLink {
+                    if let app = _importedApps.first {
+                        ModernSigningView(app: app)
+                    } else {
+                        noAppsToSignView
+                    }
+                } label: {
+                    QuickActionCardContent(
+                        title: "Sign & Install",
+                        icon: "signature",
+                        color: .purple
+                    )
+                }
+                .disabled(_importedApps.isEmpty && _signedApps.isEmpty)
+            }
+        }
+        .opacity(_appearAnimation ? 1 : 0)
+        .offset(y: _appearAnimation ? 0 : 20)
+        .animation(.spring(response: 0.5, dampingFraction: 0.8).delay(0.1), value: _appearAnimation)
+    }
+    
+    private var noAppsToSignView: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "app.badge.fill")
+                .font(.system(size: 60))
+                .foregroundStyle(.secondary)
+            
+            Text("No Apps to Sign")
+                .font(.title2.bold())
+            
+            Text("Import an app first to sign and install it.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .navigationTitle("Sign App")
+    }
+    
+    // MARK: - Status Section
+    private var statusSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            sectionHeader("Status", icon: "chart.bar.fill")
+            
+            VStack(spacing: 12) {
+                HStack(spacing: 12) {
+                    StatusCard(
+                        title: "Portal Version",
+                        value: "v\(portalVersion)",
+                        subtitle: "Build \(buildNumber)",
+                        icon: "app.badge.checkmark.fill",
+                        color: .blue
+                    )
+                    
+                    StatusCard(
+                        title: "Sources",
+                        value: "\(_sources.count)",
+                        subtitle: _sources.count == 1 ? "repository" : "repositories",
+                        icon: "globe.desk.fill",
+                        color: .cyan
+                    )
+                }
+                
+                HStack(spacing: 12) {
+                    StatusCard(
+                        title: "Certificates",
+                        value: "\(_certificates.count)",
+                        subtitle: _certificates.count == 1 ? "certificate" : "certificates",
+                        icon: "checkmark.seal.fill",
+                        color: .green
+                    )
+                    
+                    StatusCard(
+                        title: "Signed Apps",
+                        value: "\(_signedApps.count)",
+                        subtitle: _signedApps.count == 1 ? "app signed" : "apps signed",
+                        icon: "signature",
+                        color: .purple
+                    )
+                }
+            }
+        }
+        .opacity(_appearAnimation ? 1 : 0)
+        .offset(y: _appearAnimation ? 0 : 20)
+        .animation(.spring(response: 0.5, dampingFraction: 0.8).delay(0.2), value: _appearAnimation)
+    }
+    
+    // MARK: - At A Glance Section
+    private var atAGlanceSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            sectionHeader("At A Glance", icon: "eye.fill")
+            
+            VStack(spacing: 12) {
+                // Total Apps Available
+                AtAGlanceRow(
+                    title: "Total Apps Available",
+                    value: "\(totalAppsAvailable)",
+                    icon: "app.badge.fill",
+                    color: .blue
+                )
+                
+                // Library Apps
+                AtAGlanceRow(
+                    title: "Apps in Library",
+                    value: "\(_signedApps.count + _importedApps.count)",
+                    icon: "square.grid.2x2.fill",
+                    color: .orange
+                )
+                
+                // Certificate Status
+                if let selectedCert = getSelectedCertificate() {
+                    AtAGlanceRow(
+                        title: "Active Certificate",
+                        value: selectedCert.nickname ?? "Unknown",
+                        icon: "checkmark.shield.fill",
+                        color: selectedCert.revoked ? .red : .green
+                    )
+                    
+                    if let expiration = selectedCert.expiration {
+                        AtAGlanceRow(
+                            title: "Certificate Expires",
+                            value: formatExpirationDate(expiration),
+                            icon: "calendar.badge.clock",
+                            color: expirationColor(expiration)
+                        )
+                    }
+                } else {
+                    AtAGlanceRow(
+                        title: "Certificate Status",
+                        value: "No certificate selected",
+                        icon: "exclamationmark.shield.fill",
+                        color: .orange
+                    )
+                }
+                
+                // Recent Activity
+                if let recentSigned = _signedApps.first {
+                    AtAGlanceRow(
+                        title: "Last Signed App",
+                        value: recentSigned.name ?? "Unknown",
+                        icon: "clock.fill",
+                        color: .purple
+                    )
+                }
+                
+                // Storage Info
+                AtAGlanceRow(
+                    title: "Unsigned Apps",
+                    value: "\(_importedApps.count)",
+                    icon: "doc.badge.plus",
+                    color: .gray
+                )
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(UIColor.secondarySystemGroupedBackground))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color(UIColor.separator).opacity(0.2), lineWidth: 0.5)
+            )
+        }
+        .opacity(_appearAnimation ? 1 : 0)
+        .offset(y: _appearAnimation ? 0 : 20)
+        .animation(.spring(response: 0.5, dampingFraction: 0.8).delay(0.3), value: _appearAnimation)
+    }
+    
+    // MARK: - Helper Views
+    @ViewBuilder
+    private func sectionHeader(_ title: String, icon: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.accentColor)
+            
+            Text(title)
+                .font(.system(size: 18, weight: .bold, design: .rounded))
+                .foregroundStyle(.primary)
+        }
+    }
+    
+    // MARK: - Helper Properties
+    private var totalAppsAvailable: Int {
+        _sources.reduce(0) { total, source in
+            total + (viewModel.sources[source]?.apps.count ?? 0)
+        }
+    }
+    
+    private func getSelectedCertificate() -> CertificatePair? {
+        let selectedIndex = UserDefaults.standard.integer(forKey: "feather.selectedCert")
+        return Storage.shared.getCertificate(for: selectedIndex)
+    }
+    
+    private func formatExpirationDate(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+    
+    private func expirationColor(_ date: Date) -> Color {
+        let daysUntilExpiration = Calendar.current.dateComponents([.day], from: Date(), to: date).day ?? 0
+        if daysUntilExpiration < 0 {
+            return .red
+        } else if daysUntilExpiration < 7 {
+            return .orange
+        } else if daysUntilExpiration < 30 {
+            return .yellow
+        } else {
+            return .green
+        }
+    }
+}
+
+// MARK: - Quick Action Card
+struct QuickActionCard: View {
+    let title: String
+    let icon: String
+    let color: Color
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            QuickActionCardContent(title: title, icon: icon, color: color)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct QuickActionCardContent: View {
+    let title: String
+    let icon: String
+    let color: Color
+    
+    var body: some View {
+        VStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(color.opacity(0.15))
+                    .frame(width: 50, height: 50)
+                
+                Image(systemName: icon)
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(color)
+            }
+            
+            Text(title)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(UIColor.secondarySystemGroupedBackground))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color(UIColor.separator).opacity(0.2), lineWidth: 0.5)
+        )
+    }
+}
+
+// MARK: - Status Card
+struct StatusCard: View {
+    let title: String
+    let value: String
+    let subtitle: String
+    let icon: String
+    let color: Color
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(color)
+                
+                Spacer()
+            }
+            
+            Text(value)
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+                .foregroundStyle(.primary)
+            
+            Text(title)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.secondary)
+            
+            Text(subtitle)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(UIColor.secondarySystemGroupedBackground))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(color.opacity(0.2), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - At A Glance Row
+struct AtAGlanceRow: View {
+    let title: String
+    let value: String
+    let icon: String
+    let color: Color
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(color.opacity(0.15))
+                    .frame(width: 36, height: 36)
+                
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(color)
+            }
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+                
+                Text(value)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+            }
+            
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/Feather/Views/Settings/Appearance/TabBarCustomizationView.swift
+++ b/Feather/Views/Settings/Appearance/TabBarCustomizationView.swift
@@ -3,13 +3,14 @@ import NimbleViews
 
 // MARK: - TabBarCustomizationView
 struct TabBarCustomizationView: View {
-    @AppStorage("Feather.tabBar.home") private var showHome = true
+    @AppStorage("Feather.tabBar.dashboard") private var showDashboard = true
+    @AppStorage("Feather.tabBar.sources") private var showSources = true
     @AppStorage("Feather.tabBar.library") private var showLibrary = true
     @AppStorage("Feather.tabBar.files") private var showFiles = false
     @AppStorage("Feather.tabBar.guides") private var showGuides = true
-    @AppStorage("Feather.tabBar.order") private var tabOrder: String = "home,guides,library,files,settings"
+    @AppStorage("Feather.tabBar.order") private var tabOrder: String = "dashboard,sources,guides,library,files,settings"
     @AppStorage("Feather.tabBar.hideLabels") private var hideTabLabels = false
-    @AppStorage("Feather.tabBar.defaultTab") private var defaultTab: String = "home"
+    @AppStorage("Feather.tabBar.defaultTab") private var defaultTab: String = "dashboard"
     // Settings cannot be disabled
     
     @State private var showMinimumWarning = false
@@ -18,7 +19,8 @@ struct TabBarCustomizationView: View {
     
     private var availableDefaultTabs: [String] {
         var tabs: [String] = []
-        if showHome { tabs.append("home") }
+        if showDashboard { tabs.append("dashboard") }
+        if showSources { tabs.append("sources") }
         if showGuides { tabs.append("guides") }
         if showLibrary { tabs.append("library") }
         if showFiles { tabs.append("files") }
@@ -51,7 +53,8 @@ struct TabBarCustomizationView: View {
             } footer: {
                 Text(.localized("Choose which tab opens by default when you launch the app (Beta)."))
             }
-            .onChange(of: showHome) { _ in validateDefaultTab() }
+            .onChange(of: showDashboard) { _ in validateDefaultTab() }
+            .onChange(of: showSources) { _ in validateDefaultTab() }
             .onChange(of: showLibrary) { _ in validateDefaultTab() }
             .onChange(of: showFiles) { _ in validateDefaultTab() }
             .onChange(of: showGuides) { _ in validateDefaultTab() }
@@ -160,9 +163,12 @@ struct TabBarCustomizationView: View {
     private func tabIcon(for tabId: String) -> some View {
         Group {
             switch tabId {
-            case "home":
+            case "dashboard":
                 Image(systemName: "house.fill")
                     .foregroundStyle(.blue)
+            case "sources":
+                Image(systemName: "globe.desk.fill")
+                    .foregroundStyle(.cyan)
             case "library":
                 Image(systemName: "square.grid.2x2")
                     .foregroundStyle(.purple)
@@ -185,7 +191,8 @@ struct TabBarCustomizationView: View {
     
     private func tabName(for tabId: String) -> String {
         switch tabId {
-        case "home": return String.localized("Home")
+        case "dashboard": return String.localized("Home")
+        case "sources": return String.localized("Sources")
         case "library": return String.localized("Library")
         case "files": return String.localized("Files")
         case "guides": return String.localized("Guides")
@@ -197,8 +204,8 @@ struct TabBarCustomizationView: View {
     @ViewBuilder
     private func tabRow(for tabId: String) -> some View {
         switch tabId {
-        case "home":
-            Toggle(isOn: $showHome) {
+        case "dashboard":
+            Toggle(isOn: $showDashboard) {
                 HStack {
                     Image(systemName: "house.fill")
                         .foregroundStyle(.blue)
@@ -206,8 +213,20 @@ struct TabBarCustomizationView: View {
                     Text(.localized("Home"))
                 }
             }
-            .disabled(!canDisable(.home))
-            .onChange(of: showHome) { _ in validateMinimumTabs() }
+            .disabled(!canDisable(.dashboard))
+            .onChange(of: showDashboard) { _ in validateMinimumTabs() }
+            
+        case "sources":
+            Toggle(isOn: $showSources) {
+                HStack {
+                    Image(systemName: "globe.desk.fill")
+                        .foregroundStyle(.cyan)
+                        .frame(width: 24)
+                    Text(.localized("Sources"))
+                }
+            }
+            .disabled(!canDisable(.sources))
+            .onChange(of: showSources) { _ in validateMinimumTabs() }
             
         case "library":
             Toggle(isOn: $showLibrary) {
@@ -264,7 +283,7 @@ struct TabBarCustomizationView: View {
     
     private func loadTabOrder() {
         let tabs = tabOrder.split(separator: ",").map(String.init)
-        orderedTabs = tabs.isEmpty ? ["home", "guides", "library", "files", "settings"] : tabs
+        orderedTabs = tabs.isEmpty ? ["dashboard", "sources", "guides", "library", "files", "settings"] : tabs
     }
     
     private func moveTab(from source: IndexSet, to destination: Int) {
@@ -295,28 +314,29 @@ struct TabBarCustomizationView: View {
     }
     
     private func resetTabOrder() {
-        orderedTabs = ["home", "guides", "library", "files", "settings"]
+        orderedTabs = ["dashboard", "sources", "guides", "library", "files", "settings"]
         saveTabOrder()
     }
     
     private func validateMinimumTabs() {
-        let visibleCount = [showHome, showLibrary, showFiles, showGuides].filter { $0 }.count + 1 // +1 for Settings
+        let visibleCount = [showDashboard, showSources, showLibrary, showFiles, showGuides].filter { $0 }.count + 1 // +1 for Settings
         if visibleCount < 2 {
             showMinimumWarning = true
             // Revert the last change
-            if !showHome && !showLibrary && !showFiles && !showGuides {
+            if !showDashboard && !showSources && !showLibrary && !showFiles && !showGuides {
                 // Need at least one non-settings tab
-                showHome = true
+                showDashboard = true
             }
         }
     }
     
     private func canDisable(_ tab: TabEnum) -> Bool {
-        let visibleCount = [showHome, showLibrary, showFiles, showGuides].filter { $0 }.count + 1
+        let visibleCount = [showDashboard, showSources, showLibrary, showFiles, showGuides].filter { $0 }.count + 1
         if visibleCount <= 2 {
             // Check if this specific tab is currently enabled
             switch tab {
-            case .home: return !showHome
+            case .dashboard: return !showDashboard
+            case .sources: return !showSources
             case .library: return !showLibrary
             case .files: return !showFiles
             case .guides: return !showGuides

--- a/Feather/Views/TabView/Bars/CustomTabBarUI.swift
+++ b/Feather/Views/TabView/Bars/CustomTabBarUI.swift
@@ -2,15 +2,16 @@ import SwiftUI
 
 // MARK: - Custom Tab Bar View (Liquid Glass Design)
 struct CustomTabBarUI: View {
-    @AppStorage("Feather.tabBar.home") private var showHome = true
+    @AppStorage("Feather.tabBar.dashboard") private var showDashboard = true
+    @AppStorage("Feather.tabBar.sources") private var showSources = true
     @AppStorage("Feather.tabBar.library") private var showLibrary = true
     @AppStorage("Feather.tabBar.files") private var showFiles = false
     @AppStorage("Feather.tabBar.guides") private var showGuides = true
-    @AppStorage("Feather.tabBar.order") private var tabOrder: String = "home,guides,library,files,settings"
+    @AppStorage("Feather.tabBar.order") private var tabOrder: String = "dashboard,sources,guides,library,files,settings"
     @AppStorage("Feather.certificateExperience") private var certificateExperience: String = "Developer"
     @AppStorage("forceShowGuides") private var forceShowGuides = false
     
-    @State private var selectedTab: TabEnum = .home
+    @State private var selectedTab: TabEnum = .dashboard
     @State private var showInstallModifySheet = false
     @State private var appToInstall: (any AppInfoPresentable)?
     @State private var hoverScale: CGFloat = 1.0
@@ -22,7 +23,8 @@ struct CustomTabBarUI: View {
     
     var visibleTabs: [TabEnum] {
         var enabledTabs: [TabEnum] = []
-        if showHome { enabledTabs.append(.home) }
+        if showDashboard { enabledTabs.append(.dashboard) }
+        if showSources { enabledTabs.append(.sources) }
         if showGuides && (forceShowGuides || certificateExperience == "Enterprise") {
             enabledTabs.append(.guides)
         }
@@ -213,7 +215,8 @@ struct TabButtonStyle: ButtonStyle {
 extension TabEnum {
     var selectedIcon: String {
         switch self {
-        case .home: return "house.fill"
+        case .dashboard: return "house.fill"
+        case .sources: return "globe.desk.fill"
         case .library: return "square.stack.3d.up.fill"
         case .files: return "folder.fill"
         case .guides: return "book.fill"

--- a/Feather/Views/TabView/Bars/ExtendedTabbarView.swift
+++ b/Feather/Views/TabView/Bars/ExtendedTabbarView.swift
@@ -9,13 +9,14 @@ import NukeUI
 struct ExtendedTabbarView: View {
 	@Environment(\.horizontalSizeClass) var horizontalSizeClass
 	@AppStorage("Feather.tabCustomization") var customization = TabViewCustomization()
-	@AppStorage("Feather.tabBar.home") private var showHome = true
+	@AppStorage("Feather.tabBar.dashboard") private var showDashboard = true
+	@AppStorage("Feather.tabBar.sources") private var showSources = true
 	@AppStorage("Feather.tabBar.library") private var showLibrary = true
 	@AppStorage("Feather.tabBar.files") private var showFiles = true
 	@AppStorage("Feather.tabBar.guides") private var showGuides = true
-	@AppStorage("Feather.tabBar.order") private var tabOrder: String = "home,guides,library,files,settings"
+	@AppStorage("Feather.tabBar.order") private var tabOrder: String = "dashboard,sources,guides,library,files,settings"
 	@AppStorage("Feather.tabBar.hideLabels") private var hideTabLabels = false
-	@AppStorage("Feather.tabBar.defaultTab") private var defaultTab: String = "home"
+	@AppStorage("Feather.tabBar.defaultTab") private var defaultTab: String = "dashboard"
 	@AppStorage("Feather.certificateExperience") private var certificateExperience: String = "Developer"
 	@AppStorage("forceShowGuides") private var forceShowGuides = false
 	@StateObject var viewModel = SourcesViewModel.shared
@@ -37,7 +38,8 @@ struct ExtendedTabbarView: View {
 	
 	var visibleTabs: [TabEnum] {
 		var enabledTabs: [TabEnum] = []
-		if showHome { enabledTabs.append(.home) }
+		if showDashboard { enabledTabs.append(.dashboard) }
+		if showSources { enabledTabs.append(.sources) }
 		if showLibrary { enabledTabs.append(.library) }
 		if showFiles { enabledTabs.append(.files) }
 		
@@ -74,7 +76,8 @@ struct ExtendedTabbarView: View {
 	
 	private func getInitialTab() -> TabEnum {
 		switch defaultTab {
-		case "home": return visibleTabs.contains(.home) ? .home : visibleTabs.first ?? .settings
+		case "dashboard": return visibleTabs.contains(.dashboard) ? .dashboard : visibleTabs.first ?? .settings
+		case "sources": return visibleTabs.contains(.sources) ? .sources : visibleTabs.first ?? .settings
 		case "library": return visibleTabs.contains(.library) ? .library : visibleTabs.first ?? .settings
 		case "files": return visibleTabs.contains(.files) ? .files : visibleTabs.first ?? .settings
 		case "guides": return visibleTabs.contains(.guides) ? .guides : visibleTabs.first ?? .settings

--- a/Feather/Views/TabView/Bars/TabbarView.swift
+++ b/Feather/Views/TabView/Bars/TabbarView.swift
@@ -2,13 +2,14 @@
 import SwiftUI
 
 struct TabbarView: View {
-	@AppStorage("Feather.tabBar.home") private var showHome = true
+	@AppStorage("Feather.tabBar.dashboard") private var showDashboard = true
+	@AppStorage("Feather.tabBar.sources") private var showSources = true
 	@AppStorage("Feather.tabBar.library") private var showLibrary = true
 	@AppStorage("Feather.tabBar.files") private var showFiles = false
 	@AppStorage("Feather.tabBar.guides") private var showGuides = true
-	@AppStorage("Feather.tabBar.order") private var tabOrder: String = "home,guides,library,files,settings"
+	@AppStorage("Feather.tabBar.order") private var tabOrder: String = "dashboard,sources,guides,library,files,settings"
 	@AppStorage("Feather.tabBar.hideLabels") private var hideTabLabels = false
-	@AppStorage("Feather.tabBar.defaultTab") private var defaultTab: String = "home"
+	@AppStorage("Feather.tabBar.defaultTab") private var defaultTab: String = "dashboard"
 	@AppStorage("Feather.certificateExperience") private var certificateExperience: String = "Developer"
 	@AppStorage("forceShowGuides") private var forceShowGuides = false
 	
@@ -22,7 +23,8 @@ struct TabbarView: View {
 	
 	var visibleTabs: [TabEnum] {
 		var enabledTabs: [TabEnum] = []
-		if showHome { enabledTabs.append(.home) }
+		if showDashboard { enabledTabs.append(.dashboard) }
+		if showSources { enabledTabs.append(.sources) }
 		if showGuides && (forceShowGuides || certificateExperience == "Enterprise") {
 			enabledTabs.append(.guides)
 		}
@@ -54,7 +56,8 @@ struct TabbarView: View {
 	
 	private func getInitialTab() -> TabEnum {
 		switch defaultTab {
-		case "home": return visibleTabs.contains(.home) ? .home : visibleTabs.first ?? .settings
+		case "dashboard": return visibleTabs.contains(.dashboard) ? .dashboard : visibleTabs.first ?? .settings
+		case "sources": return visibleTabs.contains(.sources) ? .sources : visibleTabs.first ?? .settings
 		case "library": return visibleTabs.contains(.library) ? .library : visibleTabs.first ?? .settings
 		case "files": return visibleTabs.contains(.files) ? .files : visibleTabs.first ?? .settings
 		case "guides": return visibleTabs.contains(.guides) ? .guides : visibleTabs.first ?? .settings

--- a/Feather/Views/TabView/TabEnum.swift
+++ b/Feather/Views/TabView/TabEnum.swift
@@ -3,7 +3,8 @@ import SwiftUI
 import NimbleViews
 
 enum TabEnum: String, CaseIterable, Hashable {
-	case home
+	case dashboard
+	case sources
 	case library
 	case settings
 	case certificates
@@ -12,7 +13,8 @@ enum TabEnum: String, CaseIterable, Hashable {
 	
 	var title: String {
 		switch self {
-		case .home:     	return .localized("Home")
+		case .dashboard:	return .localized("Home")
+		case .sources:     	return .localized("Sources")
 		case .library: 		return .localized("Library")
 		case .settings: 	return .localized("Settings")
 		case .certificates:	return .localized("Certificates")
@@ -23,7 +25,8 @@ enum TabEnum: String, CaseIterable, Hashable {
 	
 	var icon: String {
 		switch self {
-		case .home: 		return "house.fill"
+		case .dashboard:	return "house.fill"
+		case .sources: 		return "globe.desk.fill"
 		case .library: 		return "square.grid.2x2"
 		case .settings: 	return "gearshape.2"
 		case .certificates: return "person.text.rectangle"
@@ -35,7 +38,8 @@ enum TabEnum: String, CaseIterable, Hashable {
 	@ViewBuilder
 	static func view(for tab: TabEnum) -> some View {
 		switch tab {
-		case .home: SourcesView()
+		case .dashboard: HomeView()
+		case .sources: SourcesView()
 		case .library: LibraryView()
 		case .settings: SettingsView()
 		case .certificates: NBNavigationView(.localized("Certificates")) { CertificatesView() }
@@ -46,7 +50,8 @@ enum TabEnum: String, CaseIterable, Hashable {
 	
 	static var defaultTabs: [TabEnum] {
 		return [
-			.home,
+			.dashboard,
+			.sources,
 			.guides,
 			.library,
 			.settings


### PR DESCRIPTION
… Glance sections

- Created new HomeView.swift with:
  - Quick Actions: Add Certificate, Add Source, Import App, Sign & Install
  - Status section: Portal version, sources count, certificates count, signed apps count
  - At A Glance section: Total apps available, library apps, active certificate info, certificate expiration, last signed app, unsigned apps count

- Renamed existing Home tab to Sources tab
- Added new Dashboard tab as the default home
- Updated TabEnum with new .dashboard and .sources cases
- Updated all tab bar views (TabbarView, ExtendedTabbarView, CustomTabBarUI, ExperimentalTabbarView)
- Updated TabBarCustomizationView to allow toggling the new Home (Dashboard) tab visibility