### PR TITLE
Fix Swift compilation errors

### DIFF
--- a/Feather/Backend/Observable/AppUpdateTrackingManager.swift
+++ b/Feather/Backend/Observable/AppUpdateTrackingManager.swift
@@ -185,7 +185,7 @@ final class AppUpdateTrackingManager: ObservableObject {
         for trackedApp in enabledTrackedApps {
             // Find the source
             guard let sourceEntry = sources.first(where: { $0.key.sourceURL?.absoluteString == trackedApp.sourceURL }),
-                  let app = sourceEntry.value.apps.first(where: { $0.bundleIdentifier == trackedApp.bundleIdentifier }) else {
+                  let app = sourceEntry.value.apps.first(where: { $0.id == trackedApp.bundleIdentifier }) else {
                 continue
             }
             

--- a/Feather/Views/Library/LibraryView.swift
+++ b/Feather/Views/Library/LibraryView.swift
@@ -25,7 +25,7 @@ struct LibraryView: View {
     
     // Batch selection states
     @State private var _isSelectionMode = false
-    @State private var _selectedApps: Set<UUID> = []
+    @State private var _selectedApps: Set<String> = []
     @State private var _showBatchSigningSheet = false
     @State private var _showBatchDeleteConfirmation = false
     
@@ -1085,7 +1085,7 @@ struct BatchSigningView: View {
             // Initialize all apps as pending
             for app in apps {
                 if let uuid = app.uuid {
-                    signingProgress[uuid.uuidString] = .pending
+                    signingProgress[uuid] = .pending
                 }
             }
         }
@@ -1093,7 +1093,7 @@ struct BatchSigningView: View {
     
     private func getStatusForApp(_ app: AppInfoPresentable) -> BatchSigningStatus {
         guard let uuid = app.uuid else { return .pending }
-        return signingProgress[uuid.uuidString] ?? .pending
+        return signingProgress[uuid] ?? .pending
     }
     
     private var headerSection: some View {
@@ -1263,7 +1263,7 @@ struct BatchSigningView: View {
         // Reset all statuses to pending
         for app in apps {
             if let uuid = app.uuid {
-                signingProgress[uuid.uuidString] = .pending
+                signingProgress[uuid] = .pending
             }
         }
         
@@ -1287,11 +1287,9 @@ struct BatchSigningView: View {
             return
         }
         
-        let uuidString = uuid.uuidString
-        
         // Update status to signing
         withAnimation {
-            signingProgress[uuidString] = .signing
+            signingProgress[uuid] = .signing
         }
         
         // Get the selected certificate
@@ -1312,7 +1310,7 @@ struct BatchSigningView: View {
             if let error = error {
                 // Signing failed
                 withAnimation {
-                    signingProgress[uuidString] = .failed(error.localizedDescription)
+                    signingProgress[uuid] = .failed(error.localizedDescription)
                     failedCount += 1
                     overallProgress = Double(completedCount + failedCount) / Double(apps.count)
                 }
@@ -1320,7 +1318,7 @@ struct BatchSigningView: View {
             } else {
                 // Signing succeeded
                 withAnimation {
-                    signingProgress[uuidString] = .success
+                    signingProgress[uuid] = .success
                     completedCount += 1
                     overallProgress = Double(completedCount + failedCount) / Double(apps.count)
                 }

--- a/Feather/Views/Settings/Home/HomeSettingsView.swift
+++ b/Feather/Views/Settings/Home/HomeSettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import NimbleViews
+import AltSourceKit
 
 // MARK: - Widget Size
 enum WidgetSize: String, CaseIterable, Codable, Identifiable {
@@ -944,13 +945,13 @@ struct SelectAppToTrackView: View {
         if !searchText.isEmpty {
             apps = apps.filter { item in
                 (item.app.name?.localizedCaseInsensitiveContains(searchText) ?? false) ||
-                (item.app.bundleIdentifier?.localizedCaseInsensitiveContains(searchText) ?? false)
+                (item.app.id?.localizedCaseInsensitiveContains(searchText) ?? false)
             }
         }
         
         // Filter out already tracked apps
         apps = apps.filter { item in
-            guard let bundleId = item.app.bundleIdentifier else { return false }
+            guard let bundleId = item.app.id else { return false }
             return !updateManager.isAppTracked(bundleIdentifier: bundleId)
         }
         
@@ -998,7 +999,7 @@ struct SelectAppToTrackView: View {
                         }
                     } else {
                         Section {
-                            ForEach(filteredApps, id: \.app.bundleIdentifier) { item in
+                            ForEach(filteredApps, id: \.app.id) { item in
                                 SelectableAppRow(
                                     app: item.app,
                                     source: item.source,
@@ -1027,7 +1028,7 @@ struct SelectAppToTrackView: View {
     }
     
     private func addAppToTracking(_ item: (source: AltSource, repo: ASRepository, app: ASRepository.App)) {
-        guard let bundleId = item.app.bundleIdentifier,
+        guard let bundleId = item.app.id,
               let version = item.app.version else { return }
         
         let config = TrackedAppConfig(


### PR DESCRIPTION
- Fix ASRepository.App property access: use .id instead of .bundleIdentifier (bundleIdentifier is the JSON key, id is the Swift property)
- Fix UUID/String type mismatch in LibraryView.swift: change _selectedApps from Set<UUID> to Set<String> since app.uuid is String?
- Remove invalid .uuidString calls on String type in batch signing code
- Add missing import AltSourceKit in HomeSettingsView.swift