### PR TITLE
fix: Resolve Swift compilation errors

### DIFF
--- a/Feather/Views/Settings/Appearance/SFSymbolsPickerView.swift
+++ b/Feather/Views/Settings/Appearance/SFSymbolsPickerView.swift
@@ -172,7 +172,7 @@ struct SFSymbolsPickerView: View {
                         }
                     } label: {
                         Image(systemName: showCustomizationPanel ? "slider.horizontal.3" : "slider.horizontal.3")
-                            .foregroundStyle(showCustomizationPanel ? .accentColor : .primary)
+                            .foregroundColor(showCustomizationPanel ? .accentColor : .primary)
                     }
                 }
             }
@@ -210,7 +210,7 @@ struct SFSymbolsPickerView: View {
             // Custom Symbol Input
             HStack(spacing: 10) {
                 Image(systemName: "plus.circle.fill")
-                    .foregroundStyle(.accentColor)
+                    .foregroundColor(.accentColor)
                 
                 TextField("Enter custom symbol name...", text: $customSymbolName)
                     .textFieldStyle(.plain)
@@ -301,7 +301,7 @@ struct SFSymbolsPickerView: View {
                 Text(title)
                     .font(.subheadline)
             }
-            .foregroundStyle(viewModel.selectedCategory == category ? .accentColor : .secondary)
+            .foregroundColor(viewModel.selectedCategory == category ? .accentColor : .secondary)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 8)
             .background(

--- a/Feather/Views/Signing/ModernSigningView.swift
+++ b/Feather/Views/Signing/ModernSigningView.swift
@@ -1736,9 +1736,9 @@ struct BinaryInspectorView: View {
                 }
             } else {
                 Section {
-                    InfoRow(title: "Executable", value: app.name ?? "Unknown")
-                    InfoRow(title: "Bundle ID", value: app.identifier ?? "Unknown")
-                    InfoRow(title: "Version", value: app.version ?? "Unknown")
+                    SigningInfoRow(title: "Executable", value: app.name ?? "Unknown")
+                    SigningInfoRow(title: "Bundle ID", value: app.identifier ?? "Unknown")
+                    SigningInfoRow(title: "Version", value: app.version ?? "Unknown")
                 } header: {
                     Text("App Info")
                 }
@@ -1753,7 +1753,7 @@ struct BinaryInspectorView: View {
                 
                 Section {
                     ForEach(binaryInfo.sorted(by: { $0.key < $1.key }), id: \.key) { key, value in
-                        InfoRow(title: key, value: value)
+                        SigningInfoRow(title: key, value: value)
                     }
                 } header: {
                     Text("Binary Details")
@@ -2289,8 +2289,8 @@ struct SigningLogsDebugView: View {
     }
 }
 
-// MARK: - Info Row Helper
-private struct InfoRow: View {
+// MARK: - Signing Info Row Helper
+private struct SigningInfoRow: View {
     let title: String
     let value: String
     


### PR DESCRIPTION
- Replace .foregroundStyle(.accentColor) with .foregroundColor(.accentColor) in SFSymbolsPickerView
- Rename InfoRow to SigningInfoRow in ModernSigningView to avoid redeclaration conflict