### PR TITLE
Fix Swift compilation errors

### DIFF
--- a/Feather/Backend/Observable/AppUpdateTrackingManager.swift
+++ b/Feather/Backend/Observable/AppUpdateTrackingManager.swift
@@ -205,15 +205,17 @@ final class AppUpdateTrackingManager: ObservableObject {
                 }
                 
                 completedCount += 1
+                let currentProgress = Double(completedCount) / Double(totalSources)
                 await MainActor.run {
-                    autoFetchProgress = Double(completedCount) / Double(totalSources)
+                    autoFetchProgress = currentProgress
                 }
             }
             
             // Clear old cache and update with new data
+            let sourcesToCache = fetchedSources
             await MainActor.run {
                 clearCache()
-                updateCache(from: fetchedSources)
+                updateCache(from: sourcesToCache)
                 saveLastAutoFetchDate()
                 isFetchingAllSources = false
                 autoFetchProgress = 1.0

--- a/Feather/Views/Signing/ModernSigningView.swift
+++ b/Feather/Views/Signing/ModernSigningView.swift
@@ -2218,26 +2218,6 @@ struct AdvancedDebugToolsView: View {
     }
 }
 
-// MARK: - FileManager Extension for Directory Size
-extension FileManager {
-    func allocatedSizeOfDirectory(at url: URL) throws -> UInt64 {
-        var size: UInt64 = 0
-        let resourceKeys: Set<URLResourceKey> = [.isRegularFileKey, .fileAllocatedSizeKey, .totalFileAllocatedSizeKey]
-        
-        guard let enumerator = self.enumerator(at: url, includingPropertiesForKeys: Array(resourceKeys), options: [], errorHandler: nil) else {
-            return 0
-        }
-        
-        for case let fileURL as URL in enumerator {
-            let resourceValues = try fileURL.resourceValues(forKeys: resourceKeys)
-            guard resourceValues.isRegularFile == true else { continue }
-            size += UInt64(resourceValues.totalFileAllocatedSize ?? resourceValues.fileAllocatedSize ?? 0)
-        }
-        
-        return size
-    }
-}
-
 // MARK: - Binary Inspector View
 struct BinaryInspectorView: View {
     let app: AppInfoPresentable


### PR DESCRIPTION
- Remove duplicate allocatedSizeOfDirectory(at:) function from ModernSigningView.swift (keeping the one in DeveloperView.swift to resolve redeclaration error)
- Fix Swift 6 concurrency error in AppUpdateTrackingManager.swift by capturing mutable variables in local immutable copies before passing to MainActor.run