### PR TITLE
Fix type mismatch in BackupRestoreView fileImporter callback

### DIFF
--- a/Feather/Views/Settings/Backup & Restore/BackupRestoreView.swift
+++ b/Feather/Views/Settings/Backup & Restore/BackupRestoreView.swift
@@ -225,7 +225,8 @@ struct BackupRestoreView: View {
 			allowsMultipleSelection: false
 		) { result in
 			switch result {
-			case .success(let url):
+			case .success(let urls):
+				guard let url = urls.first else { return }
 				if isVerifying {
 					verifyBackup(at: url)
 					isVerifying = false


### PR DESCRIPTION
Fixed a type mismatch in BackupRestoreView.swift where an array of URLs was being passed to functions expecting a single URL. Added a guard statement to extract the first URL from the fileImporter's result.

---
*PR created automatically by Jules for task [8785305076586660786](https://jules.google.com/task/8785305076586660786) started by @dylans2010*