### PR TITLE
Fix Backup Import Flow and Permission Error

### DIFF
--- a/Feather/Views/Settings/Backup & Restore/BackupRestoreView.swift
+++ b/Feather/Views/Settings/Backup & Restore/BackupRestoreView.swift
@@ -165,6 +165,7 @@ struct BackupRestoreView: View {
 							}
 							
 							Button {
+								showBackupOptions = false
 								isImporting = true
 							} label: {
 								HStack(spacing: 8) {
@@ -212,6 +213,7 @@ struct BackupRestoreView: View {
 					}
 
 					Button {
+						showBackupOptions = false
 						isVerifying = true
 						isImporting = true
 					} label: {
@@ -349,12 +351,8 @@ struct BackupRestoreView: View {
 		let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 
 		do {
-			guard url.startAccessingSecurityScopedResource() else {
-				UIAlertController.showAlertWithOk(title: .localized("Error"), message: .localized("Permission denied for the selected file."))
-				return
-			}
-			defer { url.stopAccessingSecurityScopedResource() }
-
+			// FileImporterRepresentableView uses asCopy: true, so the file is already copied
+			// and we don't need security-scoped resource access. Calling it would return false.
 			try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
 			try FileManager.default.unzipItem(at: url, to: tempDir)
 
@@ -612,13 +610,8 @@ struct BackupRestoreView: View {
 		restoreProgress = 0.0
 		
 		do {
-			guard url.startAccessingSecurityScopedResource() else {
-				isRestoring = false
-				UIAlertController.showAlertWithOk(title: .localized("Error"), message: .localized("Permission denied for the selected file."))
-				return
-			}
-			defer { url.stopAccessingSecurityScopedResource() }
-			
+			// FileImporterRepresentableView uses asCopy: true, so the file is already copied
+			// and we don't need security-scoped resource access. Calling it would return false.
 			try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
 			
 			// Unzip backup


### PR DESCRIPTION
This change fixes two issues in the Backup & Restore view:
1. It ensures the Backup Options splash screen is never shown when the user clicks the Import or Verify Backup buttons by explicitly resetting the `showBackupOptions` state.
2. It resolves a "Permission denied" error during file import. The error was caused by calling `startAccessingSecurityScopedResource()` on a URL that was already a local copy (provided by `FileImporterRepresentableView` with `asCopy: true`), which incorrectly returned `false` and triggered the error message. Removing these calls allows the import to proceed correctly.

---
*PR created automatically by Jules for task [17383025151896726102](https://jules.google.com/task/17383025151896726102) started by @dylans2010*