### PR TITLE
Fix .fileImporter type mismatch in BackupRestoreView

### DIFF
--- a/Feather/Views/Settings/Backup & Restore/BackupRestoreView.swift
+++ b/Feather/Views/Settings/Backup & Restore/BackupRestoreView.swift
@@ -262,8 +262,8 @@ struct BackupRestoreView: View {
             allowsMultipleSelection: false
         ) { result in
             switch result {
-            case .success(let url):
-                pendingRestoreURL = url
+            case .success(let urls):
+                pendingRestoreURL = urls.first
                 showRestoreDialog = true
             case .failure(let error):
                 AppLogManager.shared.error("Failed to pick backup file: \(error.localizedDescription)", category: "Backup & Restore")
@@ -275,8 +275,10 @@ struct BackupRestoreView: View {
             allowsMultipleSelection: false
         ) { result in
             switch result {
-            case .success(let url):
-                handleVerifyBackup(at: url)
+            case .success(let urls):
+                if let url = urls.first {
+                    handleVerifyBackup(at: url)
+                }
             case .failure(let error):
                 AppLogManager.shared.error("Failed to pick backup file for verification: \(error.localizedDescription)", category: "Backup & Restore")
             }


### PR DESCRIPTION
This change fixes build failures in Feather/Views/Settings/Backup & Restore/BackupRestoreView.swift by correcting the handling of SwiftUI's .fileImporter result. The result payload is an array of URLs ([URL]), but the code was incorrectly treating it as a single URL. I updated both occurrences to use .first to get the relevant URL.

---
*PR created automatically by Jules for task [880077626624364666](https://jules.google.com/task/880077626624364666) started by @dylans2010*