### PR TITLE
Fix build errors: resolve ScaleButtonStyle redeclaration and missing Combine import

### DIFF
--- a/Feather/Views/Settings/Credits/CreditsView.swift
+++ b/Feather/Views/Settings/Credits/CreditsView.swift
@@ -242,7 +242,7 @@ struct GitHubCreditCard: View {
 			.scaleEffect(cardScale)
 			.opacity(cardOpacity)
 		}
-		.buttonStyle(ScaleButtonStyle())
+		.buttonStyle(CreditsScaleButtonStyle())
 		.onAppear {
 			// Fetch GitHub user data using the explicit GitHub username
 			viewModel.fetchUser(username: credit.githubUsername)
@@ -262,7 +262,7 @@ struct GitHubCreditCard: View {
 }
 
 // MARK: - Scale Button Style
-struct ScaleButtonStyle: ButtonStyle {
+struct CreditsScaleButtonStyle: ButtonStyle {
 	func makeBody(configuration: Configuration) -> some View {
 		configuration.label
 			.scaleEffect(configuration.isPressed ? 0.95 : 1.0)

--- a/Feather/Views/Sources/Apps/AllAppsView.swift
+++ b/Feather/Views/Sources/Apps/AllAppsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AltSourceKit
 import NimbleViews
+import Combine
 
 // MARK: - Did You Know Facts
 struct DidYouKnowFacts {
@@ -593,7 +594,7 @@ struct AllAppsRowView: View {
 			.cornerRadius(16)
 			.shadow(color: Color.black.opacity(0.02), radius: 10, x: 0, y: 5)
 		}
-		.buttonStyle(ScaleButtonStyle())
+		.buttonStyle(AllAppsScaleButtonStyle())
 		.onAppear(perform: setupObserver)
 		.onDisappear { cancellable?.cancel() }
 		.onChange(of: downloadManager.downloads.description) { _ in
@@ -701,7 +702,7 @@ struct AllAppsRowView: View {
 }
 
 // MARK: - Scale Button Style
-struct ScaleButtonStyle: ButtonStyle {
+struct AllAppsScaleButtonStyle: ButtonStyle {
 	func makeBody(configuration: Configuration) -> some View {
 		configuration.label
 			.scaleEffect(configuration.isPressed ? 0.97 : 1.0)


### PR DESCRIPTION
This PR fixes multiple compilation errors that were blocking the build. 

1. **Redeclaration of ScaleButtonStyle**: The `ScaleButtonStyle` struct was defined in both `CreditsView.swift` and `AllAppsView.swift`. Since their implementations were slightly different (scale factor and damping), they have been renamed to `CreditsScaleButtonStyle` and `AllAppsScaleButtonStyle` respectively to avoid the conflict while preserving their intended behavior.
2. **Missing Combine Types**: `AllAppsView.swift` was using `AnyCancellable` and `Publishers` but was missing the `import Combine` statement. This has been added.

---
*PR created automatically by Jules for task [10147225512323347547](https://jules.google.com/task/10147225512323347547) started by @dylans2010*