### PR TITLE
Fix compilation errors: Duplicate properties and ternary type mismatches

### DIFF
--- a/Feather/Views/Settings/Appearance/AllAppsCustomizationView.swift
+++ b/Feather/Views/Settings/Appearance/AllAppsCustomizationView.swift
@@ -29,7 +29,6 @@ struct AllAppsCustomizationView: View {
     @AppStorage("Feather.allApps.useGrid") private var useGrid: Bool = false
     @AppStorage("Feather.allApps.gridColumns") private var gridColumns: Int = 3
     @AppStorage("Feather.allApps.titleFontSize") private var titleFontSize: Double = 17.0
-    @AppStorage("Feather.allApps.subtitleFontSize") private var subtitleFontSize: Double = 13.0
     @AppStorage("Feather.allApps.boldTitles") private var boldTitles: Bool = true
     @AppStorage("Feather.allApps.useGlassEffects") private var useGlassEffects: Bool = true
     @AppStorage("Feather.allApps.showDescription") private var showDescription: Bool = false

--- a/Feather/Views/Sources/Apps/AllAppsView.swift
+++ b/Feather/Views/Sources/Apps/AllAppsView.swift
@@ -278,7 +278,7 @@ struct AllAppsView: View {
         .padding(.vertical, 10)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(_useGlassEffects ? .ultraThinMaterial : AnyShapeStyle(Color(uiColor: .secondarySystemGroupedBackground)))
+                .fill(_useGlassEffects ? AnyShapeStyle(.ultraThinMaterial) : AnyShapeStyle(Color(uiColor: .secondarySystemGroupedBackground)))
                 .overlay(
                     RoundedRectangle(cornerRadius: 14, style: .continuous)
                         .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
@@ -589,7 +589,6 @@ struct AllAppsRowView: View {
     // Advanced
     @AppStorage("Feather.allApps.useGrid") private var useGrid: Bool = false
     @AppStorage("Feather.allApps.titleFontSize") private var titleFontSize: Double = 17.0
-    @AppStorage("Feather.allApps.subtitleFontSize") private var subtitleFontSize: Double = 13.0
     @AppStorage("Feather.allApps.boldTitles") private var boldTitles: Bool = true
     @AppStorage("Feather.allApps.useGlassEffects") private var useGlassEffects: Bool = true
     @AppStorage("Feather.allApps.showDescription") private var showDescription: Bool = false
@@ -843,7 +842,7 @@ struct AllAppsRowView: View {
         }
         .padding(.vertical, rowStyle == .minimal ? 10 : 14)
         .padding(.horizontal, rowStyle == .minimal ? 4 : 14)
-        .background(rowStyle == .minimal ? Color.clear : (useGlassEffects ? AnyShapeStyle(.ultraThinMaterial) : AnyShapeStyle(Color(uiColor: .secondarySystemGroupedBackground))))
+        .background(rowStyle == .minimal ? AnyShapeStyle(Color.clear) : (useGlassEffects ? AnyShapeStyle(.ultraThinMaterial) : AnyShapeStyle(Color(uiColor: .secondarySystemGroupedBackground))))
         .cornerRadius(rowStyle == .card || rowStyle == .flat ? 16 : 0)
         .shadow(color: rowStyle == .card ? Color.black.opacity(0.02) : Color.clear, radius: 10, x: 0, y: 5)
         .overlay(


### PR DESCRIPTION
This PR fixes two main sources of compilation failure:
1. Duplicate Property Declaration: Removed redundant 'subtitleFontSize' declarations in AllAppsCustomizationView.swift and AllAppsView.swift.
2. Mismatched Types: Ensured type homogeneity in ternary expressions within AllAppsView.swift by using AnyShapeStyle for both branches of conditional styling (Material vs. Color).

---
*PR created automatically by Jules for task [2669187527932993172](https://jules.google.com/task/2669187527932993172) started by @dylans2010*