### PR TITLE
Fix misplaced availability check in AppearanceView.swift

### DIFF
--- a/Feather/Views/Settings/Appearance/AppearanceView.swift
+++ b/Feather/Views/Settings/Appearance/AppearanceView.swift
@@ -5,7 +5,7 @@ import UIKit
 // MARK: - Appearance View
 struct AppearanceView: View {
     @AppStorage("Feather.userInterfaceStyle") private var userInterfaceStyle: Int = UIUserInterfaceStyle.unspecified.rawValue
-    @AppStorage("Feather.shouldTintIcons") private var _shouldTintColors: Bool = false
+    @AppStorage("Feather.shouldTintIcons") private var _shouldTintIcons: Bool = false
     @AppStorage("Feather.storeCellAppearance") private var storeCellAppearance: Int = 0
     @AppStorage("com.apple.SwiftUI.IgnoreSolariumLinkedOnCheck") private var ignoreSolariumLinkedOnCheck: Bool = false
     @AppStorage("Feather.showNews") private var showNews: Bool = true
@@ -18,6 +18,7 @@ struct AppearanceView: View {
         List {
             themeSection
             accentColorSection
+            iconTintSection
             displaySection
             hapticsSection
             personalizationSection
@@ -63,19 +64,14 @@ struct AppearanceView: View {
         }
     }
 
-if #available(iOS 18.0, *) {
-Section {
-    Toggle("Tint App Icons", isOn: $_shouldTintIcons)
-}
-
-}
-
-
-
-
-
-
-
+    @ViewBuilder
+    private var iconTintSection: some View {
+        if #available(iOS 18.0, *) {
+            Section {
+                Toggle("Tint App Icons", isOn: $_shouldTintIcons)
+            }
+        }
+    }
     
     // MARK: - Display Section
     


### PR DESCRIPTION
This PR fixes a Swift compilation error in `AppearanceView.swift` where an availability check for iOS 18.0 was placed directly at the struct scope.

Key changes:
- Extracted the misplaced `if #available(iOS 18.0, *)` block into a new private `@ViewBuilder` property `iconTintSection`.
- Renamed the private property `_shouldTintColors` to `_shouldTintIcons` to ensure consistency with the `@AppStorage` key `"Feather.shouldTintIcons"` and the variable name used in the `Toggle`.
- Integrated `iconTintSection` into the `List` within the `body` property, immediately following the `accentColorSection`.

These changes resolve the "expected declaration" error and ensure the tint icons feature is correctly displayed on supported iOS versions.

---
*PR created automatically by Jules for task [2320422369619064735](https://jules.google.com/task/2320422369619064735) started by @dylans2010*