### PR TITLE
Implement app icon tinting in Library and Signing

### DIFF
--- a/Feather/Supporting Files/Feather-Bridging-Header.h
+++ b/Feather/Supporting Files/Feather-Bridging-Header.h
@@ -2,3 +2,4 @@
 //
 
 #include "MachOUtils.h"
+#import "iconPoc.h"

--- a/Feather/Utilities/FR.swift
+++ b/Feather/Utilities/FR.swift
@@ -40,9 +40,18 @@ enum FR {
 		completion: @escaping (Error?) -> Void
 	) {
 		Task.detached {
+			let shouldTint = UserDefaults.standard.bool(forKey: "Feather.shouldTintIcons")
+			var finalIcon = icon
+
+			if finalIcon == nil && shouldTint {
+				if let bundleURL = await MainActor.run(body: { Storage.shared.getAppDirectory(for: app) }) {
+					finalIcon = await MainActor.run(body: { iconTest(bundleURL) })
+				}
+			}
+
 			let handler = SigningHandler(app: app, options: options)
 			handler.appCertificate = certificate
-			handler.appIcon = icon
+			handler.appIcon = finalIcon
 			
 			do {
 				try await handler.copy()

--- a/Feather/Views/Common/FRAppIconView.swift
+++ b/Feather/Views/Common/FRAppIconView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct FRAppIconView: View {
 	private var _app: AppInfoPresentable
 	private var _size: CGFloat
+	@AppStorage("Feather.shouldTintIcons") private var _shouldTintIcons: Bool = false
+	@State private var _tintedIcon: UIImage?
 	
 	init(app: AppInfoPresentable, size: CGFloat = 87) {
 		self._app = app
@@ -10,6 +12,30 @@ struct FRAppIconView: View {
 	}
 	
 	var body: some View {
+		Group {
+			if _shouldTintIcons {
+				if let tintedIcon = _tintedIcon {
+					Image(uiImage: tintedIcon)
+						.appIconStyle(size: _size)
+				} else {
+					originalIconView
+						.onAppear {
+							loadTintedIcon()
+						}
+				}
+			} else {
+				originalIconView
+			}
+		}
+		.onChange(of: _shouldTintIcons) { newValue in
+			if newValue {
+				loadTintedIcon()
+			}
+		}
+	}
+
+	@ViewBuilder
+	private var originalIconView: some View {
 		if
 			let iconFilePath = Storage.shared.getAppDirectory(for: _app)?.appendingPathComponent(_app.icon ?? ""),
 			let uiImage = UIImage(contentsOfFile: iconFilePath.path)
@@ -19,6 +45,18 @@ struct FRAppIconView: View {
 		} else {
 			Image("App_Unknown")
 				.appIconStyle(size: _size)
+		}
+	}
+
+	private func loadTintedIcon() {
+		guard _shouldTintIcons else { return }
+		Task.detached(priority: .userInitiated) {
+			if let bundleURL = Storage.shared.getAppDirectory(for: _app),
+			   let tinted = iconTest(bundleURL) {
+				await MainActor.run {
+					self._tintedIcon = tinted
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This change implements the "Tint App Icons" feature. When enabled in Appearance settings, app icons in the LibraryView are dynamically tinted with the user's custom accent color. Additionally, when signing an app, the tinted version of the icon is baked into the signed bundle if no custom icon has been manually selected by the user.

Key technical improvements:
- Asynchronous icon generation in FRAppIconView to prevent main-thread blocking during list scrolling.
- Local @State caching of tinted icons in the view layer.
- Thread-safe invocation of the iconPoc logic in the signing flow.

---
*PR created automatically by Jules for task [2920991298330267557](https://jules.google.com/task/2920991298330267557) started by @dylans2010*