### PR TITLE
Improve Tinted App Icons Refresh and UI

### DIFF
--- a/Feather/Resources/iconPoc.m
+++ b/Feather/Resources/iconPoc.m
@@ -246,9 +246,18 @@ UIImage* iconTest(NSURL *bundleURL) {
 }
 
 static CGColorRef FRCreateCGColorFromHex(void) {
+	NSString *type =
+		[NSUserDefaults.standardUserDefaults
+			stringForKey:@"Feather.userTintColorType"];
+
+	NSString *key = @"Feather.userTintColor";
+	if ([type isEqualToString:@"gradient"]) {
+		key = @"Feather.userTintGradientStart";
+	}
+
 	NSString *hex =
 		[NSUserDefaults.standardUserDefaults
-			stringForKey:@"Feather.userTintColor"];
+			stringForKey:key];
 
 	if (hex.length == 0) {
 		return UIColor.systemGreenColor.CGColor;

--- a/Feather/Views/Common/FRAppIconView.swift
+++ b/Feather/Views/Common/FRAppIconView.swift
@@ -4,6 +4,11 @@ struct FRAppIconView: View {
 	private var _app: AppInfoPresentable
 	private var _size: CGFloat
 	@AppStorage("Feather.shouldTintIcons") private var _shouldTintIcons: Bool = false
+	@AppStorage("Feather.userTintColor") private var _userTintColor: String = "#0077BE"
+	@AppStorage("Feather.userTintColorType") private var _colorType: String = "solid"
+	@AppStorage("Feather.userTintGradientStart") private var _gradientStartHex: String = "#0077BE"
+	@AppStorage("Feather.userInterfaceStyle") private var _userInterfaceStyle: Int = 0
+
 	@State private var _tintedIcon: UIImage?
 	
 	init(app: AppInfoPresentable, size: CGFloat = 87) {
@@ -32,6 +37,10 @@ struct FRAppIconView: View {
 				loadTintedIcon()
 			}
 		}
+		.onChange(of: _userTintColor) { _ in loadTintedIcon() }
+		.onChange(of: _colorType) { _ in loadTintedIcon() }
+		.onChange(of: _gradientStartHex) { _ in loadTintedIcon() }
+		.onChange(of: _userInterfaceStyle) { _ in loadTintedIcon() }
 	}
 
 	@ViewBuilder

--- a/Feather/Views/Settings/Appearance/AppearanceView.swift
+++ b/Feather/Views/Settings/Appearance/AppearanceView.swift
@@ -5,7 +5,7 @@ import UIKit
 // MARK: - Appearance View
 struct AppearanceView: View {
     @AppStorage("Feather.userInterfaceStyle") private var userInterfaceStyle: Int = UIUserInterfaceStyle.unspecified.rawValue
-    @AppStorage("Feather.shouldTintIcons") private var _shouldTintColors: Bool = false
+    @AppStorage("Feather.shouldTintIcons") private var _shouldTintIcons: Bool = false
     @AppStorage("Feather.storeCellAppearance") private var storeCellAppearance: Int = 0
     @AppStorage("com.apple.SwiftUI.IgnoreSolariumLinkedOnCheck") private var ignoreSolariumLinkedOnCheck: Bool = false
     @AppStorage("Feather.showNews") private var showNews: Bool = true
@@ -70,7 +70,9 @@ struct AppearanceView: View {
     private var tintIconsSection: some View {
         if #available(iOS 18.0, *) {
             Section {
-                Toggle("Tint App Icons", isOn: $_shouldTintColors)
+                AppearanceToggle(icon: "paintpalette", title: "Tint App Icons", isOn: $_shouldTintIcons, color: .pink)
+            } footer: {
+                Text("Allow Feather to tint your app icons with the current accent color.")
             }
         }
     }


### PR DESCRIPTION
This PR improves the "Tinted App Icons" feature by ensuring icons refresh immediately when the user changes the accent color or theme settings.

Key changes:
- In `FRAppIconView.swift`, added `@AppStorage` properties and `.onChange` observers for `Feather.userTintColor`, `Feather.userTintColorType`, `Feather.userTintGradientStart`, and `Feather.userInterfaceStyle` to trigger an icon reload whenever these values change.
- In `AppearanceView.swift`, updated the "Tint App Icons" toggle to use the `AppearanceToggle` component, adding a `paintpalette` SF symbol and a descriptive footer.
- In `iconPoc.m`, updated `FRCreateCGColorFromHex` to correctly use the gradient start color if the user has selected a gradient tint type, ensuring the generated icons match the app's accent color.
- Renamed `_shouldTintColors` to `_shouldTintIcons` in `AppearanceView.swift` for consistency.

---
*PR created automatically by Jules for task [2818750634294556442](https://jules.google.com/task/2818750634294556442) started by @dylans2010*