### PR TITLE
Fix Swift 6 and SwiftUI 5 Compatibility Issues

### DIFF
--- a/Feather/Views/Common/FRAppIconView.swift
+++ b/Feather/Views/Common/FRAppIconView.swift
@@ -10,6 +10,7 @@ struct FRAppIconView: View {
 	@AppStorage("Feather.userInterfaceStyle") private var _userInterfaceStyle: Int = 0
 
 	@State private var _tintedIcon: UIImage?
+	@State private var _originalIcon: UIImage?
 	
 	init(app: AppInfoPresentable, size: CGFloat = 87) {
 		self._app = app
@@ -24,13 +25,13 @@ struct FRAppIconView: View {
 						.appIconStyle(size: _size)
 				} else {
 					originalIconView
-						.onAppear {
-							loadTintedIcon()
-						}
 				}
 			} else {
 				originalIconView
 			}
+		}
+		.task(id: _app.uuid) {
+			await loadIcons()
 		}
 		.onChange(of: _shouldTintIcons) { newValue in
 			if newValue {
@@ -45,10 +46,7 @@ struct FRAppIconView: View {
 
 	@ViewBuilder
 	private var originalIconView: some View {
-		if
-			let iconFilePath = Storage.shared.getAppDirectory(for: _app)?.appendingPathComponent(_app.icon ?? ""),
-			let uiImage = UIImage(contentsOfFile: iconFilePath.path)
-		{
+		if let uiImage = _originalIcon {
 			Image(uiImage: uiImage)
 				.appIconStyle(size: _size)
 		} else {
@@ -57,11 +55,33 @@ struct FRAppIconView: View {
 		}
 	}
 
-	private func loadTintedIcon() {
+	private func loadIcons() async {
+		guard let bundleURL = await Storage.shared.getAppDirectory(for: _app) else { return }
+
+		let iconFilePath = bundleURL.appendingPathComponent(_app.icon ?? "")
+		if let uiImage = UIImage(contentsOfFile: iconFilePath.path) {
+			await MainActor.run {
+				self._originalIcon = uiImage
+			}
+		}
+
+		if _shouldTintIcons {
+			loadTintedIcon(with: bundleURL)
+		}
+	}
+
+	private func loadTintedIcon(with bundleURL: URL? = nil) {
 		guard _shouldTintIcons else { return }
+
 		Task.detached(priority: .userInitiated) {
-			if let bundleURL = Storage.shared.getAppDirectory(for: _app),
-			   let tinted = iconTest(bundleURL) {
+			let url: URL?
+			if let bundleURL = bundleURL {
+				url = bundleURL
+			} else {
+				url = await Storage.shared.getAppDirectory(for: _app)
+			}
+
+			if let url = url, let tinted = iconTest(url) {
 				await MainActor.run {
 					self._tintedIcon = tinted
 				}

--- a/Feather/Views/Library/LibraryCellView.swift
+++ b/Feather/Views/Library/LibraryCellView.swift
@@ -72,7 +72,7 @@ struct LibraryCellView: View {
         } label: {
             Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                 .font(.system(size: 22))
-                .foregroundStyle(isSelected ? .accentColor : .secondary.opacity(0.4))
+                .foregroundStyle(isSelected ? Color.accentColor : Color.secondary.opacity(0.4))
         }
         .buttonStyle(.borderless)
     }
@@ -121,7 +121,7 @@ struct LibraryCellView: View {
         } label: {
             Text(app.isSigned ? "Install" : "Sign")
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(app.isSigned ? .green : .accentColor)
+                .foregroundStyle(app.isSigned ? Color.green : Color.accentColor)
         }
         .buttonStyle(.plain)
     }

--- a/Feather/Views/Library/LibraryView.swift
+++ b/Feather/Views/Library/LibraryView.swift
@@ -446,7 +446,7 @@ extension LibraryView {
             } label: {
                 Image(systemName: "plus.circle.fill")
                     .font(.system(size: 28))
-                    .foregroundStyle(.accentColor)
+                    .foregroundStyle(Color.accentColor)
                     .symbolRenderingMode(.hierarchical)
             }
         }
@@ -487,7 +487,7 @@ extension LibraryView {
             } label: {
                 Image(systemName: _isSelectionMode ? "checkmark.circle.fill" : "ellipsis.circle")
                     .font(.system(size: 22))
-                    .foregroundStyle(_isSelectionMode ? .accentColor : .secondary)
+                    .foregroundStyle(_isSelectionMode ? Color.accentColor : Color.secondary)
             }
             .buttonStyle(.plain)
         }
@@ -511,7 +511,7 @@ extension LibraryView {
                     } label: {
                         Text("Sign \(unsignedSelectedApps.count)")
                             .font(.system(size: 15, weight: .semibold))
-                            .foregroundStyle(.accentColor)
+                            .foregroundStyle(Color.accentColor)
                     }
                     .buttonStyle(.plain)
                 }
@@ -631,7 +631,7 @@ extension LibraryView {
             } label: {
                 Text("Import")
                     .font(.system(size: 17, weight: .semibold))
-                    .foregroundStyle(.accentColor)
+                    .foregroundStyle(Color.accentColor)
             }
             .padding(.top, 8)
             
@@ -708,7 +708,7 @@ struct PremiumAppCard: View {
             } label: {
                 Text(app.isSigned ? "Install" : "Sign")
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(app.isSigned ? .green : .accentColor)
+                    .foregroundStyle(app.isSigned ? Color.green : Color.accentColor)
             }
             .buttonStyle(.plain)
         }
@@ -1006,7 +1006,7 @@ struct BatchSigningView: View {
                             .frame(width: 8, height: 8)
                         Text(currentPhase == .installing ? "Installing" : (currentPhase == .completed ? "Completed" : "Signing"))
                             .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(currentPhase == .installing ? .green : (currentPhase == .completed ? .green : .accentColor))
+                            .foregroundStyle(currentPhase == .installing ? Color.green : (currentPhase == .completed ? Color.green : Color.accentColor))
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
@@ -1064,7 +1064,7 @@ struct BatchSigningView: View {
                             RoundedRectangle(cornerRadius: 6)
                                 .fill(
                                     LinearGradient(
-                                        colors: currentPhase == .installing ? [.green, .green.opacity(0.8)] : [.accentColor, .accentColor.opacity(0.8)],
+                                        colors: currentPhase == .installing ? [Color.green, Color.green.opacity(0.8)] : [Color.accentColor, Color.accentColor.opacity(0.8)],
                                         startPoint: .leading,
                                         endPoint: .trailing
                                     )
@@ -1269,13 +1269,13 @@ struct BatchSigningView: View {
                         .padding(.vertical, 16)
                         .background(
                             LinearGradient(
-                                colors: certificates.isEmpty ? [.gray, .gray.opacity(0.85)] : [.accentColor, .accentColor.opacity(0.85)],
+                                colors: certificates.isEmpty ? [Color.gray, Color.gray.opacity(0.85)] : [Color.accentColor, Color.accentColor.opacity(0.85)],
                                 startPoint: .topLeading,
                                 endPoint: .bottomTrailing
                             )
                         )
                         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                        .shadow(color: certificates.isEmpty ? .clear : .accentColor.opacity(0.3), radius: 10, x: 0, y: 5)
+                        .shadow(color: certificates.isEmpty ? Color.clear : Color.accentColor.opacity(0.3), radius: 10, x: 0, y: 5)
                     }
                     .disabled(certificates.isEmpty)
                 }


### PR DESCRIPTION
This submission fixes two specific categories of errors encountered when updating to Swift 6 and SwiftUI 5:

1. **Async Property Access**: `Storage.shared.getAppDirectory(for:)` is now asynchronous in Swift 6 mode. `FRAppIconView.swift` has been refactored to load icons asynchronously and cache them in `@State` variables, using the modern `.task(id:)` modifier for efficient lifecycle management.

2. **Accent Color Removal**: SwiftUI 5 removed `.accentColor` as a valid member of `ShapeStyle`. All occurrences in `LibraryCellView.swift` and `LibraryView.swift` have been updated to use `Color.accentColor`. Additionally, ternary expressions involving colors have been updated to ensure both branches evaluate to the same concrete type (`Color`), preventing compilation errors.

---
*PR created automatically by Jules for task [12623709909661169158](https://jules.google.com/task/12623709909661169158) started by @dylans2010*