### PR TITLE
Fix compile error and unused variable in BackupRestoreView

### DIFF
--- a/Feather/Views/Settings/Backup & Restore/BackupRestoreView.swift
+++ b/Feather/Views/Settings/Backup & Restore/BackupRestoreView.swift
@@ -494,7 +494,6 @@ struct BackupRestoreView: View {
                 // 3c. Imported Apps
                 let importedSourceDir = tempRestoreDir.appendingPathComponent("imported_apps")
                 if fileManager.fileExists(atPath: importedSourceDir.path) {
-                    let importedDestDir = fileManager.unsigned
                     let contents = (try? fileManager.contentsOfDirectory(at: importedSourceDir, includingPropertiesForKeys: nil)) ?? []
                     for file in contents {
                         let uuid = file.deletingPathExtension().lastPathComponent
@@ -662,7 +661,7 @@ struct BackupRestoreView: View {
                 UIApplication.shared.suspendAndReopen()
             }
         })
-        alert.present(animated: true, completion: nil)
+        UIApplication.topViewController()?.present(alert, animated: true, completion: nil)
     }
 
     private func handleExportLogs() {


### PR DESCRIPTION
This PR fixes a Swift compile error in `BackupRestoreView.swift` where a `UIAlertController` was incorrectly attempting to present itself using an invalid method signature. The fix uses `UIApplication.topViewController()` to obtain a valid presenter. Additionally, an unused variable `importedDestDir` was removed to resolve a compiler warning.

---
*PR created automatically by Jules for task [11840009712850680524](https://jules.google.com/task/11840009712850680524) started by @dylans2010*