### PR TITLE
Fix SwiftUI Font Modifier Compilation Errors

### DIFF
--- a/Feather/Views/Settings/Backup & Restore/BackupRestoreView.swift
+++ b/Feather/Views/Settings/Backup & Restore/BackupRestoreView.swift
@@ -169,7 +169,7 @@ struct BackupRestoreView: View {
                                 .foregroundStyle(.green)
                         }
                         Text(.localized("Create Backup"))
-                            .font(.system(.subheadline, weight: .bold, design: .rounded))
+                            .font(.system(size: 15, weight: .bold, design: .rounded))
                             .foregroundStyle(.green)
                     }
                     .frame(maxWidth: .infinity)
@@ -192,7 +192,7 @@ struct BackupRestoreView: View {
                                 .foregroundStyle(.blue)
                         }
                         Text(.localized("Restore Backup"))
-                            .font(.system(.subheadline, weight: .bold, design: .rounded))
+                            .font(.system(size: 15, weight: .bold, design: .rounded))
                             .foregroundStyle(.blue)
                     }
                     .frame(maxWidth: .infinity)

--- a/Feather/Views/Settings/Storage/ManageStorageView.swift
+++ b/Feather/Views/Settings/Storage/ManageStorageView.swift
@@ -707,13 +707,13 @@ struct ManageStorageView: View {
                     }
                     
                     Text(.localized("Total"))
-                        .font(.system(.body, design: .default, weight: .bold))
+                        .font(.system(size: 17, weight: .bold, design: .default))
                         .foregroundStyle(.primary)
                     
                     Spacer()
                     
                     Text(formatBytes(totalFeatherStorage))
-                        .font(.system(.title3, design: .rounded, weight: .bold))
+                        .font(.system(size: 20, weight: .bold, design: .rounded))
                         .foregroundStyle(Color.accentColor)
                 }
                 .padding(.vertical, 8)


### PR DESCRIPTION
The build was failing because the `.font(.system(...))` modifier was being called with both a `TextStyle` (like `.subheadline`) and a `weight:` argument, which is not a valid overload in SwiftUI. I've updated these calls to use the `size:` based overload with the appropriate point sizes for each style, as requested by the user. I also applied the same fix to `ManageStorageView.swift` to ensure project-wide consistency and a successful build.

---
*PR created automatically by Jules for task [13454822797556455613](https://jules.google.com/task/13454822797556455613) started by @dylans2010*