### PR TITLE
Fix extraneous closing brace in ColorCustomizationView.swift

### DIFF
--- a/Feather/Views/Settings/Appearance/Colors/ColorCustomizationView.swift
+++ b/Feather/Views/Settings/Appearance/Colors/ColorCustomizationView.swift
@@ -609,8 +609,6 @@ struct ColorCustomizationView: View {
         sheetBGHex = "#F2F2F7"
         HapticsManager.shared.success()
     }
-}
-
 // MARK: - App-Wide Color Picker Sheet
 
 private struct AppWideColorPickerSheet: View {


### PR DESCRIPTION
### Motivation
- Resolve a Swift parser error (`extraneous '}' at top level`) caused by an extra closing brace at the end of `Feather/Views/Settings/Appearance/Colors/ColorCustomizationView.swift` which prevented the project from compiling.

### Description
- Remove the redundant closing brace at the end of `ColorCustomizationView.swift` so the `// MARK: - App-Wide Color Picker Sheet` section and the `AppWideColorPickerSheet` struct are correctly nested and the file has balanced braces.

### Testing
- No automated tests were run for this targeted syntax-only fix; this change should allow the Swift compiler/CI to proceed past the previous parsing error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc7117c5308320a75e04411be647f2)