### PR TITLE
Guard presentationBackground for iOS 16.4+

### DIFF
--- a/Feather/Backend/Models/ThemedViewModifier.swift
+++ b/Feather/Backend/Models/ThemedViewModifier.swift
@@ -128,10 +128,18 @@ struct ThemedSheetModifier: ViewModifier {
     @EnvironmentObject var themeManager: ThemeManager
 
     func body(content: Content) -> some View {
-        content
-            .background(themeManager.background)
-            .presentationBackground(themeManager.background)
-            .tint(themeManager.accent)
+        Group {
+            if #available(iOS 16.4, *) {
+                content
+                    .background(themeManager.background)
+                    .presentationBackground(themeManager.background)
+                    .tint(themeManager.accent)
+            } else {
+                content
+                    .background(themeManager.background)
+                    .tint(themeManager.accent)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Fix a build error caused by using the `.presentationBackground` modifier that is only available on iOS 16.4+, by preventing its use on older OS versions.

### Description
- Update `Feather/Backend/Models/ThemedViewModifier.swift` so `ThemedSheetModifier` wraps the view in a `Group` and applies `.presentationBackground(themeManager.background)` only inside `if #available(iOS 16.4, *)`, while keeping `.background(themeManager.background)` and `.tint(themeManager.accent)` for all OS versions.

### Testing
- Ran `swift build`, which failed because this repository is not a SwiftPM package (no `Package.swift`), so no further automated build or test was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc76fdbd0c8320b5bdd1f98007d741)