### PR TITLE
Fix extraneous brace in PairedDevicesView.swift

### DIFF
--- a/Feather/Views/Settings/Pairing/MultipeerConnectivity/PairedDevicesView.swift
+++ b/Feather/Views/Settings/Pairing/MultipeerConnectivity/PairedDevicesView.swift
@@ -45,7 +45,6 @@ struct PairedDevicesView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-                    }
                     .listStyle(.insetGrouped)
                     .scrollContentBackground(.hidden)
                 }


### PR DESCRIPTION
Fixed a Swift compilation error in `PairedDevicesView.swift` where an extra closing brace was causing the `PairedDevicesView` struct to close prematurely. This led to the "extraneous '}' at top level" error at the end of the file. By removing the misplaced brace after the `ZStack` content, the view modifiers and subsequent methods are now correctly scoped within the struct.

---
*PR created automatically by Jules for task [9192293119736426190](https://jules.google.com/task/9192293119736426190) started by @dylans2010*